### PR TITLE
Add benches, make no_std, and add serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ rand = "0.3"
 
 [features]
 std = []
-default = ["std", "serde/std"]
+default = [ "std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,12 @@ readme = "README.md"
 keywords = []
 license = "MIT"
 
+[dependencies]
+serde = { version = "1", optional = true,  default-features = false, features = ["alloc", "derive"] }
+
 [dev-dependencies]
 rand = "0.3"
+
+[features]
+std = []
+default = ["std", "serde/std"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,79 @@
+#![feature(test)]
+
+extern crate splay_tree;
+extern crate test;
+
+use splay_tree::SplayMap;
+
+const SMALL: u32 = 10;
+const MEDIUM: u32 = 100;
+const BIG: u32 = 1000;
+const HUGE: u32 = 10_000_000;
+
+fn insert_splay(b: &mut test::Bencher, num: u32) {
+    let mut map = SplayMap::new();
+    for i in 0..num {
+        map.insert(i, i);
+    }
+    let mut j = num + 1;
+    b.iter(|| {
+        j += 1;
+        map.insert(j, j);
+    })
+}
+
+fn get_middle_splay(b: &mut test::Bencher, num: u32) {
+    let mut map = SplayMap::new();
+    for i in 0..num {
+        map.insert(i, i);
+    }
+    let middle = num / 2;
+    b.iter(|| {
+        test::black_box(map.get(&middle));
+    })
+}
+
+fn get_none_splay(b: &mut test::Bencher, num: u32) {
+    let mut map = SplayMap::new();
+    for i in 0..num {
+        map.insert(i, i);
+    }
+    let none = num + 1;
+    b.iter(|| {
+        test::black_box(map.get(&none));
+    })
+}
+
+#[bench]
+fn bench_insert_splay_small(b: &mut test::Bencher) {
+    insert_splay(b, SMALL);
+}
+#[bench]
+fn bench_insert_splay_medium(b: &mut test::Bencher) {
+    insert_splay(b, MEDIUM);
+}
+#[bench]
+fn bench_insert_splay_big(b: &mut test::Bencher) {
+    insert_splay(b, BIG);
+}
+#[bench]
+fn bench_insert_splay_huge(b: &mut test::Bencher) {
+    insert_splay(b, HUGE);
+}
+
+#[bench]
+fn bench_get_none_splay_small(b: &mut test::Bencher) {
+    get_none_splay(b, SMALL);
+}
+#[bench]
+fn bench_get_none_splay_medium(b: &mut test::Bencher) {
+    get_none_splay(b, MEDIUM);
+}
+#[bench]
+fn bench_get_none_splay_big(b: &mut test::Bencher) {
+    get_none_splay(b, BIG);
+}
+#[bench]
+fn bench_get_none_splay_huge(b: &mut test::Bencher) {
+    get_none_splay(b, HUGE);
+}

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,7 +1,7 @@
 //! A priority queue implemented with a splay tree.
 use std;
 use std::cmp;
-use core;
+use tree_core;
 use iter;
 
 /// `SplayHeap` iterator.
@@ -9,7 +9,7 @@ pub struct Iter<'a, T: 'a> {
     iter: iter::Iter<'a, Item<T>, ()>,
 }
 impl<'a, T: 'a> Iter<'a, T> {
-    fn new(tree: &'a core::Tree<Item<T>, ()>) -> Self {
+    fn new(tree: &'a tree_core::Tree<Item<T>, ()>) -> Self {
         Iter { iter: tree.iter() }
     }
 }
@@ -73,7 +73,7 @@ impl<T> Ord for Item<T>
 /// ```
 #[derive(Debug,Clone)]
 pub struct SplayHeap<T> {
-    tree: core::Tree<Item<T>, ()>,
+    tree: tree_core::Tree<Item<T>, ()>,
     seq: u64,
 }
 impl<T> SplayHeap<T>
@@ -91,7 +91,7 @@ impl<T> SplayHeap<T>
     /// ```
     pub fn new() -> Self {
         SplayHeap {
-            tree: core::Tree::new(),
+            tree: tree_core::Tree::new(),
             seq: 0,
         }
     }
@@ -163,7 +163,7 @@ impl<T> SplayHeap<T>
     /// assert!(heap.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        self.tree = core::Tree::new();
+        self.tree = tree_core::Tree::new();
     }
 }
 impl<T> SplayHeap<T> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,8 @@
 //! Iterators for splay tree
 use std::mem;
-use core::Node;
-use core::NodeIndex;
+use tree_core::Node;
+use tree_core::NodeIndex;
+use std::vec::Vec;
 
 pub type MaybeNodeIndex = Option<NodeIndex>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,24 @@
 //! Splay tree based data structures
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
 #![warn(missing_docs)]
-mod core;
+
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+pub extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::{ops, hash, fmt, cmp, mem, slice, iter, borrow, u32};
+    pub use alloc::*;
+}
+
+
+mod tree_core;
 mod iter;
 mod vec_like;
 pub mod map;

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,7 @@
 use std;
 use std::mem;
 use std::borrow::Borrow;
-use core;
+use tree_core;
 use iter;
 
 /// A map based on a splay tree.
@@ -51,7 +51,7 @@ use iter;
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SplayMap<K, V> {
-    tree: core::Tree<K, V>,
+    tree: tree_core::Tree<K, V>,
 }
 impl<K, V> SplayMap<K, V>
     where K: Ord
@@ -67,7 +67,7 @@ impl<K, V> SplayMap<K, V>
     /// assert_eq!(map.len(), 1);
     /// ```
     pub fn new() -> Self {
-        SplayMap { tree: core::Tree::new() }
+        SplayMap { tree: tree_core::Tree::new() }
     }
 
     /// Clears the map, removing all values.
@@ -82,7 +82,7 @@ impl<K, V> SplayMap<K, V>
     /// assert!(map.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        self.tree = core::Tree::new();
+        self.tree = tree_core::Tree::new();
     }
 
     /// Returns true if the map contains a value for the specified key.
@@ -528,7 +528,7 @@ impl<'a, K, V> Extend<(&'a K, &'a V)> for SplayMap<K, V>
 /// An iterator over a SplayMap's entries.
 pub struct Iter<'a, K: 'a, V: 'a>(iter::Iter<'a, K, V>);
 impl<'a, K: 'a, V: 'a> Iter<'a, K, V> {
-    fn new(tree: &'a core::Tree<K, V>) -> Self {
+    fn new(tree: &'a tree_core::Tree<K, V>) -> Self {
         Iter(tree.iter())
     }
 }
@@ -542,7 +542,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
 /// A mutable iterator over a SplayMap's entries.
 pub struct IterMut<'a, K: 'a, V: 'a>(iter::IterMut<'a, K, V>);
 impl<'a, K: 'a, V: 'a> IterMut<'a, K, V> {
-    fn new(tree: &'a mut core::Tree<K, V>) -> Self {
+    fn new(tree: &'a mut tree_core::Tree<K, V>) -> Self {
         IterMut(tree.iter_mut())
     }
 }
@@ -556,7 +556,7 @@ impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
 /// An owning iterator over a SplayMap's entries.
 pub struct IntoIter<K, V>(iter::IntoIter<K, V>);
 impl<K, V> IntoIter<K, V> {
-    fn new(tree: core::Tree<K, V>) -> Self {
+    fn new(tree: tree_core::Tree<K, V>) -> Self {
         IntoIter(tree.into_iter())
     }
 }
@@ -570,7 +570,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
 /// An iterator over a SplayMap's keys.
 pub struct Keys<'a, K: 'a, V: 'a>(Iter<'a, K, V>);
 impl<'a, K: 'a, V: 'a> Keys<'a, K, V> {
-    fn new(tree: &'a core::Tree<K, V>) -> Self {
+    fn new(tree: &'a tree_core::Tree<K, V>) -> Self {
         Keys(Iter::new(tree))
     }
 }
@@ -584,7 +584,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Keys<'a, K, V> {
 /// An iterator over a SplayMap's values.
 pub struct Values<'a, K: 'a, V: 'a>(Iter<'a, K, V>);
 impl<'a, K: 'a, V: 'a> Values<'a, K, V> {
-    fn new(tree: &'a core::Tree<K, V>) -> Self {
+    fn new(tree: &'a tree_core::Tree<K, V>) -> Self {
         Values(Iter::new(tree))
     }
 }
@@ -598,7 +598,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Values<'a, K, V> {
 /// A mutable iterator over a SplayMap's values.
 pub struct ValuesMut<'a, K: 'a, V: 'a>(IterMut<'a, K, V>);
 impl<'a, K: 'a, V: 'a> ValuesMut<'a, K, V> {
-    fn new(tree: &'a mut core::Tree<K, V>) -> Self {
+    fn new(tree: &'a mut tree_core::Tree<K, V>) -> Self {
         ValuesMut(IterMut::new(tree))
     }
 }
@@ -648,7 +648,7 @@ impl<'a, K: 'a, V: 'a> Entry<'a, K, V>
 
 /// An occupied Entry.
 pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
-    tree: &'a mut core::Tree<K, V>,
+    tree: &'a mut tree_core::Tree<K, V>,
 }
 impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V>
     where K: Ord
@@ -688,7 +688,7 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V>
 /// A vacant Entry.
 pub struct VacantEntry<'a, K: 'a, V: 'a> {
     key: K,
-    tree: &'a mut core::Tree<K, V>,
+    tree: &'a mut tree_core::Tree<K, V>,
 }
 impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V>
     where K: Ord

--- a/src/set.rs
+++ b/src/set.rs
@@ -4,7 +4,7 @@ use std::ops;
 use std::cmp;
 use std::iter::Peekable;
 use std::borrow::Borrow;
-use core;
+use tree_core;
 use iter;
 use vec_like;
 
@@ -37,7 +37,7 @@ use vec_like;
 /// ```
 #[derive(Debug,Clone,Hash,PartialEq,Eq,PartialOrd,Ord)]
 pub struct SplaySet<T> {
-    tree: core::Tree<T, ()>,
+    tree: tree_core::Tree<T, ()>,
 }
 impl<T> SplaySet<T>
     where T: Ord
@@ -52,7 +52,7 @@ impl<T> SplaySet<T>
     /// assert!(set.is_empty());
     /// ```
     pub fn new() -> Self {
-        SplaySet { tree: core::Tree::new() }
+        SplaySet { tree: tree_core::Tree::new() }
     }
 
     /// Clears the set, removing all values.
@@ -67,7 +67,7 @@ impl<T> SplaySet<T>
     /// assert!(set.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        self.tree = core::Tree::new();
+        self.tree = tree_core::Tree::new();
     }
 
     /// Returns true if the set contains a value.
@@ -824,7 +824,7 @@ pub struct VecLike<'a, T: 'a> {
     inner: vec_like::VecLike<'a, T, ()>,
 }
 impl<'a, T: 'a> VecLike<'a, T> {
-    fn new(tree: &'a core::Tree<T, ()>) -> Self {
+    fn new(tree: &'a tree_core::Tree<T, ()>) -> Self {
         VecLike { inner: vec_like::VecLike::new(tree) }
     }
 
@@ -1027,7 +1027,7 @@ impl<'a, T: 'a> VecLikeMut<'a, T>
     }
 }
 impl<'a, T: 'a> VecLikeMut<'a, T> {
-    fn new(tree: &'a mut core::Tree<T, ()>) -> Self {
+    fn new(tree: &'a mut tree_core::Tree<T, ()>) -> Self {
         VecLikeMut { inner: vec_like::VecLikeMut::new(tree) }
     }
 

--- a/src/tree_core.rs
+++ b/src/tree_core.rs
@@ -6,12 +6,14 @@ use std::hash;
 use std::slice;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::vec::Vec;
 use iter;
 
 pub type NodeIndex = u32;
 const NULL_NODE: NodeIndex = u32::MAX;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Node<K, V> {
     lft: NodeIndex,
     rgt: NodeIndex,
@@ -59,6 +61,7 @@ impl<'a, K, V> Into<(&'a K, &'a mut V)> for &'a mut Node<K, V> {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tree<K, V> {
     root: NodeIndex,
     nodes: Vec<Node<K, V>>,

--- a/src/vec_like.rs
+++ b/src/vec_like.rs
@@ -1,13 +1,13 @@
 use std::slice;
 use std::borrow::Borrow;
-use core;
+use tree_core;
 
 #[derive(Debug, Clone)]
 pub struct VecLike<'a, K: 'a, V: 'a> {
-    tree: &'a core::Tree<K, V>,
+    tree: &'a tree_core::Tree<K, V>,
 }
 impl<'a, K: 'a, V: 'a> VecLike<'a, K, V> {
-    pub fn new(tree: &'a core::Tree<K, V>) -> Self {
+    pub fn new(tree: &'a tree_core::Tree<K, V>) -> Self {
         VecLike { tree: tree }
     }
     pub fn len(&self) -> usize {
@@ -15,7 +15,7 @@ impl<'a, K: 'a, V: 'a> VecLike<'a, K, V> {
     }
     pub fn get(&self, index: usize) -> Option<(&'a K, &'a V)> {
         if index < self.tree.len() {
-            Some(self.tree.node_ref(index as core::NodeIndex).into())
+            Some(self.tree.node_ref(index as tree_core::NodeIndex).into())
         } else {
             None
         }
@@ -34,7 +34,7 @@ impl<'a, K: 'a, V: 'a> VecLike<'a, K, V> {
 
 #[derive(Debug)]
 pub struct VecLikeMut<'a, K: 'a, V: 'a> {
-    tree: &'a mut core::Tree<K, V>,
+    tree: &'a mut tree_core::Tree<K, V>,
 }
 impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V>
     where K: Ord
@@ -62,7 +62,7 @@ impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V>
     }
 }
 impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V> {
-    pub fn new(tree: &'a mut core::Tree<K, V>) -> Self {
+    pub fn new(tree: &'a mut tree_core::Tree<K, V>) -> Self {
         VecLikeMut { tree: tree }
     }
     pub fn len(&self) -> usize {
@@ -70,7 +70,7 @@ impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V> {
     }
     pub fn get(&self, index: usize) -> Option<(&K, &V)> {
         if index < self.tree.len() {
-            Some(self.tree.node_ref(index as core::NodeIndex).into())
+            Some(self.tree.node_ref(index as tree_core::NodeIndex).into())
         } else {
             None
         }
@@ -78,7 +78,7 @@ impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V> {
     #[allow(dead_code)]
     pub fn get_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
         if index < self.tree.len() {
-            Some(self.tree.node_mut(index as core::NodeIndex).into())
+            Some(self.tree.node_mut(index as tree_core::NodeIndex).into())
         } else {
             None
         }
@@ -108,7 +108,7 @@ impl<'a, K: 'a, V: 'a> VecLikeMut<'a, K, V> {
     }
 }
 
-pub struct Iter<'a, K: 'a, V: 'a>(slice::Iter<'a, core::Node<K, V>>);
+pub struct Iter<'a, K: 'a, V: 'a>(slice::Iter<'a, tree_core::Node<K, V>>);
 impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -116,7 +116,7 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
     }
 }
 
-pub struct IterMut<'a, K: 'a, V: 'a>(slice::IterMut<'a, core::Node<K, V>>);
+pub struct IterMut<'a, K: 'a, V: 'a>(slice::IterMut<'a, tree_core::Node<K, V>>);
 impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
This is a PR to 

- (optionally) make the library work on `no_std` (using alloc), 
- (optionally) use serde,
- add benchmarks.

While the changes might seem numerous, they're all individually quite small.